### PR TITLE
(.gitlab-ci.yml) Add OpenDingux target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ xcuserdata
 profile
 *.moved-aside
 *.o
+*.so
 *.bc
 *.js
 *.json

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -88,6 +88,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/libnx-static.yml'
 
+  # OpenDingux
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/dingux-mips32.yml'
+
 # Stages for building
 stages:
   - build-prepare
@@ -225,4 +229,10 @@ libretro-build-wiiu:
 libretro-build-libnx-aarch64:
   extends:
     - .libretro-libnx-static-retroarch-master
+    - .core-defs
+
+# OpenDingux
+libretro-build-dingux-mips32:
+  extends:
+    - .libretro-dingux-mips32-make-default
     - .core-defs

--- a/Makefile
+++ b/Makefile
@@ -323,7 +323,7 @@ else ifeq ($(platform), gcw0)
 	SHARED := -shared -Wl,--no-undefined -Wl,--version-script=link.T
 	LDFLAGS += $(PTHREAD_FLAGS) -lrt
 	FLAGS += $(PTHREAD_FLAGS) -DHAVE_MKDIR
-	FLAGS += -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
+	FLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32r2 -mhard-float
 	fpic := -fPIC
 
 # Windows MSVC 2003 Xbox 1


### PR DESCRIPTION
This PR adds an OpenDingux target to the `.gitlab-ci.yml` file. Tested on an RG350M, essentially every game runs full speed with 2x video filters.