### PR TITLE
Add paddle digital sensitivity core option

### DIFF
--- a/libretro_core_options.h
+++ b/libretro_core_options.h
@@ -75,6 +75,34 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+   {
+      "stella2014_paddle_digital_sensitivity",
+      "Paddle Sensitivity (Digital)",
+      "Sets the sensitivity for digital emulation of paddle movement. Higher values increase paddle speed.",
+      {
+         { "10",  "10%" },
+         { "15",  "15%" },
+         { "20",  "20%" },
+         { "25",  "25%" },
+         { "30",  "30%" },
+         { "35",  "35%" },
+         { "40",  "40%" },
+         { "45",  "45%" },
+         { "50",  "50%" },
+         { "55",  "55%" },
+         { "60",  "60%" },
+         { "65",  "65%" },
+         { "70",  "70%" },
+         { "75",  "75%" },
+         { "80",  "80%" },
+         { "85",  "85%" },
+         { "90",  "90%" },
+         { "95",  "95%" },
+         { "100", "100%" },
+         { NULL, NULL },
+      },
+      "50"
+   },
    { NULL, NULL, NULL, {{0}}, NULL },
 };
 

--- a/stella/src/emucore/Paddles.cxx
+++ b/stella/src/emucore/Paddles.cxx
@@ -419,11 +419,18 @@ bool Paddles::setMouseControl(
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Paddles::setDigitalSensitivity(int sensitivity)
 {
-  if(sensitivity < 1)       sensitivity = 1;
-  else if(sensitivity > 10) sensitivity = 10;
+  float sensitivity_factor;
 
-  _DIGITAL_SENSITIVITY = sensitivity;
-  _DIGITAL_DISTANCE = 20 + (sensitivity << 3);
+  if(sensitivity < 10)       sensitivity = 10;
+  else if(sensitivity > 100) sensitivity = 100;
+
+  _DIGITAL_SENSITIVITY = sensitivity / 10;
+
+  /* Distance has a quadratic response */
+  sensitivity_factor = (float)sensitivity / 100.0f;
+  sensitivity_factor = sensitivity_factor * sensitivity_factor;
+
+  _DIGITAL_DISTANCE = (int)((sensitivity_factor * 100.0f) + 0.5f);
 }
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/stella/src/emucore/Paddles.hxx
+++ b/stella/src/emucore/Paddles.hxx
@@ -86,7 +86,7 @@ class Paddles : public Controller
       or digital joystick axis events); Stelladaptors or the mouse are
       not modified.
 
-      @param sensitivity  Value from 1 to 10, with larger values
+      @param sensitivity  Value from 10 to 100, with larger values
                           causing more movement
     */
     static void setDigitalSensitivity(int sensitivity);
@@ -95,7 +95,7 @@ class Paddles : public Controller
       Sets the sensitivity for analog emulation of paddle movement
       using a mouse.
 
-      @param sensitivity  Value from 1 to 10, with larger values
+      @param sensitivity  Value from 1 to 15, with larger values
                           causing more movement
     */
     static void setMouseSensitivity(int sensitivity);

--- a/stella/stubs/Stubs.hxx
+++ b/stella/stubs/Stubs.hxx
@@ -10,7 +10,7 @@ OSystem::OSystem()
     mySerialPort = new SerialPort();
     myEventHandler = new EventHandler(this);
     myPropSet = new PropertiesSet(this);
-    Paddles::setDigitalSensitivity(5);
+    Paddles::setDigitalSensitivity(50);
     Paddles::setMouseSensitivity(5);
 }
 


### PR DESCRIPTION
At present, games that use paddle controls are unplayable with this core, due to the fact that the paddle sensitivity is set to the maximum value (i.e. everything moves far too quickly).

This PR adds a new `Paddle Sensitivity (Digital)` option which allows the paddle movement speed to be adjusted. The default setting should be comfortable in most paddle-enabled games,

This closes #69

EDIT: A slight correction - the core currently sets the digital paddle sensitivity to *half* the maximum value (which is uncontrollably fast - the actual *maximum* sensitivity is plain ludicrous...)